### PR TITLE
Integrate Gemini 2.5 Flash for translation and chat response generation

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -61,7 +61,7 @@ export async function POST(req: Request) {
 
         // AIモデルで回答を生成
         const llm = new ChatGoogleGenerativeAI({ 
-            model: "gemini-2.0-flash",
+            model: "gemini-2.5-flash",
             //temperature: 2.0
         })
         //const llm = new ChatOpenAI({ model: "gpt-4" })

--- a/src/app/utils/translate.ts
+++ b/src/app/utils/translate.ts
@@ -3,7 +3,7 @@ import { generateText } from 'ai';
 
 export async function translateToEng(input: string): Promise<string> {
     const result = await generateText({
-        model: google('models/gemini-2.0-flash'),
+        model: google('models/gemini-2.5-flash'),
         prompt: `Translate the following question to English:\n\n"${input}"`,
     });
 


### PR DESCRIPTION
This pull request updates the AI model used for generating chat responses and translations to a newer version. The main change is upgrading from the `gemini-2.0-flash` model to the `gemini-2.5-flash` model in both the chat API route and the translation utility.

AI model upgrade:

* [`src/app/api/chat/route.ts`](diffhunk://#diff-a7bb5d29209ed018911d153136e25fad9cba4f3201714af7b35a7b4ef352c6d8L64-R64): Changed the model in `ChatGoogleGenerativeAI` from `"gemini-2.0-flash"` to `"gemini-2.5-flash"` for generating chat responses.
* [`src/app/utils/translate.ts`](diffhunk://#diff-fbd0ad8816f02c7e23f95024d7410de8b2775d1d832608f15ed506a68d8a5fe5L6-R6): Updated the model in the `generateText` call from `google('models/gemini-2.0-flash')` to `google('models/gemini-2.5-flash')` for translating text to English.